### PR TITLE
Add Date type and range search support

### DIFF
--- a/generator/definitions.ts
+++ b/generator/definitions.ts
@@ -5,7 +5,14 @@
 /**
  * Allowed primitive field types.
  */
-export type FieldType = 'string' | 'int' | 'float' | 'DateTime' | 'boolean' | 'enum';
+export type FieldType =
+  | 'string'
+  | 'int'
+  | 'float'
+  | 'DateTime'
+  | 'Date'
+  | 'boolean'
+  | 'enum';
 
 /**
  * Base definition for any property.
@@ -39,7 +46,7 @@ export interface NumericPropertyDefinition extends BaseProperty {
  * DateTime property (no extra constraints).
  */
 export interface DatePropertyDefinition extends BaseProperty {
-  type: 'DateTime';
+  type: 'DateTime' | 'Date';
 }
 
 /**

--- a/generator/templates/Controller.hbs
+++ b/generator/templates/Controller.hbs
@@ -22,7 +22,9 @@ namespace AspPrep.Controllers
         {{#if requiredRole}}
         [Authorize(Roles = "{{requiredRole}}")]
         {{/if}}
-        public async Task<IActionResult> Index({{#if ../pageConfig.searchFields}}{{#each ../pageConfig.searchFields}}string {{this}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}})
+        public async Task<IActionResult> Index({{#if searchFieldDefs}}{{#each searchFieldDefs}}
+            {{#if (eq type "string")}}string {{name}}{{#unless @last}}, {{/unless}}{{else if (eq type "int")}}int? {{name}}Min, int? {{name}}Max{{#unless @last}}, {{/unless}}{{else if (eq type "float")}}double? {{name}}Min, double? {{name}}Max{{#unless @last}}, {{/unless}}{{else if (eq type "Date")}}DateOnly? {{name}}Min, DateOnly? {{name}}Max{{#unless @last}}, {{/unless}}{{else if (eq type "DateTime")}}DateTime? {{name}}Min, DateTime? {{name}}Max{{#unless @last}}, {{/unless}}{{else}}string {{name}}{{#unless @last}}, {{/unless}}{{/if}}
+            {{/each}}{{/if}})
         {
             var query = _context.{{../entity.name}}.AsQueryable();
             {{#if ../entity.relations}}
@@ -30,12 +32,50 @@ namespace AspPrep.Controllers
                 {{#each ../entity.relations}}.Include(m => m.{{navigationProperty}}){{/each}}
                 .AsQueryable();
             {{/if}}
-            {{#if ../pageConfig.searchFields}}
-            {{#each ../pageConfig.searchFields}}
-            if (!string.IsNullOrEmpty({{this}}))
+            {{#if searchFieldDefs}}
+            {{#each searchFieldDefs}}
+            {{#if (eq type "string")}}
+            if (!string.IsNullOrEmpty({{name}}))
             {
-                query = query.Where(e => EF.Property<string>(e, "{{this}}").Contains({{this}}));
+                query = query.Where(e => EF.Property<string>(e, "{{name}}").Contains({{name}}));
             }
+            {{else if (eq type "int")}}
+            if ({{name}}Min.HasValue)
+            {
+                query = query.Where(e => EF.Property<int>(e, "{{name}}") >= {{name}}Min.Value);
+            }
+            if ({{name}}Max.HasValue)
+            {
+                query = query.Where(e => EF.Property<int>(e, "{{name}}") <= {{name}}Max.Value);
+            }
+            {{else if (eq type "float")}}
+            if ({{name}}Min.HasValue)
+            {
+                query = query.Where(e => EF.Property<double>(e, "{{name}}") >= {{name}}Min.Value);
+            }
+            if ({{name}}Max.HasValue)
+            {
+                query = query.Where(e => EF.Property<double>(e, "{{name}}") <= {{name}}Max.Value);
+            }
+            {{else if (eq type "Date")}}
+            if ({{name}}Min.HasValue)
+            {
+                query = query.Where(e => EF.Property<DateOnly>(e, "{{name}}") >= {{name}}Min.Value);
+            }
+            if ({{name}}Max.HasValue)
+            {
+                query = query.Where(e => EF.Property<DateOnly>(e, "{{name}}") <= {{name}}Max.Value);
+            }
+            {{else if (eq type "DateTime")}}
+            if ({{name}}Min.HasValue)
+            {
+                query = query.Where(e => EF.Property<DateTime>(e, "{{name}}") >= {{name}}Min.Value);
+            }
+            if ({{name}}Max.HasValue)
+            {
+                query = query.Where(e => EF.Property<DateTime>(e, "{{name}}") <= {{name}}Max.Value);
+            }
+            {{/if}}
             {{/each}}
             {{/if}}
             var items = await query.ToListAsync();

--- a/generator/templates/Create.hbs
+++ b/generator/templates/Create.hbs
@@ -18,6 +18,8 @@
                 <label asp-for="{{name}}" class="control-label"></label>
                 {{#if (eq type "boolean")}}
                 <input asp-for="{{name}}" class="form-check-input" type="checkbox" {{clientValidation this}} />
+                {{else if (eq type "Date")}}
+                <input asp-for="{{name}}" class="form-control" type="date" {{clientValidation this}} />
                 {{else if (eq type "DateTime")}}
                 <input asp-for="{{name}}" class="form-control" type="datetime-local" {{clientValidation this}} />
                 {{else if (eq type "enum")}}

--- a/generator/templates/Edit.hbs
+++ b/generator/templates/Edit.hbs
@@ -19,6 +19,8 @@
                 <label asp-for="{{name}}" class="control-label"></label>
                 {{#if (eq type "boolean")}}
                 <input asp-for="{{name}}" class="form-check-input" type="checkbox" {{clientValidation this}} />
+                {{else if (eq type "Date")}}
+                <input asp-for="{{name}}" class="form-control" type="date" {{clientValidation this}} />
                 {{else if (eq type "DateTime")}}
                 <input asp-for="{{name}}" class="form-control" type="datetime-local" {{clientValidation this}} />
                 {{else if (eq type "enum")}}

--- a/generator/templates/Index.hbs
+++ b/generator/templates/Index.hbs
@@ -6,13 +6,21 @@
 
 <h1>{{entity.name}} List</h1>
 
-{{#if pageConfig.searchFields}}
+{{#if searchFieldDefs}}
 <form method="get" class="mb-3">
     <div class="row">
-        {{#each pageConfig.searchFields}}
+        {{#each searchFieldDefs}}
         <div class="col-md-3">
-            <label for="{{this}}" class="form-label">{{this}}</label>
-            <input type="text" class="form-control" id="{{this}}" name="{{this}}" value="@Context.Request.Query["{{this}}"]" />
+            {{#if (eq type "string")}}
+            <label for="{{name}}" class="form-label">{{name}}</label>
+            <input type="text" class="form-control" id="{{name}}" name="{{name}}" value="@Context.Request.Query["{{name}}"]" />
+            {{else}}
+            <label class="form-label">{{name}}</label>
+            <div class="input-group">
+                <input type="{{searchInputType type}}" class="form-control" id="{{name}}Min" name="{{name}}Min" placeholder="Min" value="@Context.Request.Query["{{name}}Min"]" />
+                <input type="{{searchInputType type}}" class="form-control" id="{{name}}Max" name="{{name}}Max" placeholder="Max" value="@Context.Request.Query["{{name}}Max"]" />
+            </div>
+            {{/if}}
         </div>
         {{/each}}
         <div class="col-md-3 d-flex align-items-end">


### PR DESCRIPTION
## Summary
- support `Date` property type in generator definitions
- map `Date` to `DateOnly` and add form input handling
- add search input range support for numeric and date fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846d16d22f8832e9bde70a80987a15d