### PR TITLE
Support multiple relation display fields

### DIFF
--- a/generator/appdescription.ts
+++ b/generator/appdescription.ts
@@ -12,7 +12,7 @@ const appDescription: DefinitionsSchema = {
       name: "Concurs",
       table: "CONCURS",
       properties: [
-        { name: "Nume", type: "string", required: true, minLength: 3, maxLength: 100 },
+        { name: "Nume", type: "string", required: true, minLength: 3, maxLength: 100, showInRelations: true },
         { name: "Data", type: "DateTime", required: true },
         {
           name: "Categorie",
@@ -30,8 +30,8 @@ const appDescription: DefinitionsSchema = {
       name: "Concurent",
       table: "CONCURENT",
       properties: [
-        { name: "Nume", type: "string", required: true, minLength: 2, maxLength: 50 },
-        { name: "Prenume", type: "string", required: true, minLength: 2, maxLength: 50 },
+        { name: "Nume", type: "string", required: true, minLength: 2, maxLength: 50, showInRelations: true },
+        { name: "Prenume", type: "string", required: true, minLength: 2, maxLength: 50, showInRelations: true },
         { name: "DataNasterii", type: "DateTime", required: true },
         { name: "Tara", type: "string", required: true, minLength: 2, maxLength: 50 },
       ],
@@ -43,14 +43,14 @@ const appDescription: DefinitionsSchema = {
       name: "Band",
       table: "BAND",
       properties: [
-        { name: "Name", type: "string", required: true, minLength: 2, maxLength: 50 }
+        { name: "Name", type: "string", required: true, minLength: 2, maxLength: 50, showInRelations: true }
       ]
     },
     {
       name: "Singer",
       table: "SINGER",
       properties: [
-        { name: "Name", type: "string", required: true, minLength: 2, maxLength: 50 }
+        { name: "Name", type: "string", required: true, minLength: 2, maxLength: 50, showInRelations: true }
       ]
     }
   ],

--- a/generator/definitions.ts
+++ b/generator/definitions.ts
@@ -22,6 +22,11 @@ export interface BaseProperty {
   type: FieldType;
   required: boolean;
   autoIncrement?: boolean;
+  /**
+   * Marks this property to be displayed when referenced in relations.
+   * Multiple properties may set this flag to be concatenated in views.
+   */
+  showInRelations?: boolean;
 }
 
 /**

--- a/generator/templates/Controller.hbs
+++ b/generator/templates/Controller.hbs
@@ -92,7 +92,10 @@ namespace AspPrep.Controllers
         {
             {{#if ../entity.relations}}
             {{#each ../entity.relations}}
-            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}.ToList();
+            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
             {{/each}}
             {{/if}}
             return View();
@@ -114,7 +117,10 @@ namespace AspPrep.Controllers
             }
             {{#if ../entity.relations}}
             {{#each ../entity.relations}}
-            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}.ToList();
+            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
             {{/each}}
             {{/if}}
             return View(item);
@@ -140,7 +146,10 @@ namespace AspPrep.Controllers
             }
             {{#if ../entity.relations}}
             {{#each ../entity.relations}}
-            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}.ToList();
+            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
             {{/each}}
             {{/if}}
             return View(item);
@@ -181,7 +190,10 @@ namespace AspPrep.Controllers
             }
             {{#if ../entity.relations}}
             {{#each ../entity.relations}}
-            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}.ToList();
+            ViewData["{{navigationProperty}}List"] = _context.{{targetEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
             {{/each}}
             {{/if}}
             return View(item);

--- a/generator/templates/Create.hbs
+++ b/generator/templates/Create.hbs
@@ -40,7 +40,7 @@
             {{#each entity.relations}}
             <div class="form-group">
                 <label asp-for="{{navigationProperty}}Id" class="control-label">{{navigationProperty}}</label>
-                <select asp-for="{{navigationProperty}}Id" class="form-control" asp-items="@(new SelectList(ViewData["{{navigationProperty}}List"] as IEnumerable<dynamic>, "Id", "Nume"))">
+                <select asp-for="{{navigationProperty}}Id" class="form-control" asp-items="@(new SelectList(ViewData["{{navigationProperty}}List"] as IEnumerable<dynamic>, "Id", "DisplayName"))">
                     <option value="">-- Select {{navigationProperty}} --</option>
                 </select>
                 <span asp-validation-for="{{navigationProperty}}Id" class="text-danger"></span>

--- a/generator/templates/Delete.hbs
+++ b/generator/templates/Delete.hbs
@@ -25,7 +25,7 @@
             {{navigationProperty}}
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.{{navigationProperty}}.Nume)
+            @({{{displayInterpolationModel}}})
         </dd>
         {{/each}}
         {{/if}}

--- a/generator/templates/Edit.hbs
+++ b/generator/templates/Edit.hbs
@@ -41,7 +41,7 @@
             {{#each entity.relations}}
             <div class="form-group">
                 <label asp-for="{{navigationProperty}}Id" class="control-label">{{navigationProperty}}</label>
-                <select asp-for="{{navigationProperty}}Id" class="form-control" asp-items="@(new SelectList(ViewData["{{navigationProperty}}List"] as IEnumerable<dynamic>, "Id", "Nume"))">
+                <select asp-for="{{navigationProperty}}Id" class="form-control" asp-items="@(new SelectList(ViewData["{{navigationProperty}}List"] as IEnumerable<dynamic>, "Id", "DisplayName"))">
                     <option value="">-- Select {{navigationProperty}} --</option>
                 </select>
                 <span asp-validation-for="{{navigationProperty}}Id" class="text-danger"></span>

--- a/generator/templates/Index.hbs
+++ b/generator/templates/Index.hbs
@@ -63,7 +63,7 @@
             {{#if entity.relations}}
             {{#each entity.relations}}
             <td>
-                @Html.DisplayFor(modelItem => item.{{navigationProperty}}.Nume)
+                @({{{displayInterpolationItem}}})
             </td>
             {{/each}}
             {{/if}}


### PR DESCRIPTION
## Summary
- mark more than one property per entity to show in relations
- compute display combinations in generator
- concatenate related fields in views and dropdowns
- sample entities demonstrate multiple display fields

## Testing
- `npm run generate:all`

------
https://chatgpt.com/codex/tasks/task_e_6846dd84b5b4832e9371f4446f829502