### PR TITLE
Add Details page generation with m2m support

### DIFF
--- a/generator/definitions.ts
+++ b/generator/definitions.ts
@@ -101,7 +101,7 @@ export interface ManyToManyDefinition {
 /**
  * CRUD operations for Razor Pages, with optional role restriction.
  */
-export type PageOperation = 'list' | 'create' | 'update' | 'delete';
+export type PageOperation = 'list' | 'create' | 'update' | 'delete' | 'details';
 
 export interface OperationDefinition {
   type: PageOperation;

--- a/generator/templates/Controller.hbs
+++ b/generator/templates/Controller.hbs
@@ -83,6 +83,44 @@ namespace AspPrep.Controllers
         }
         {{/if}}
 
+        {{#if (eq type "details")}}
+        // GET: {{../entity.name}}/Details/5
+        {{#if requiredRole}}
+        [Authorize(Roles = "{{requiredRole}}")]
+        {{/if}}
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            {{#if ../entity.relations}}
+            var item = await _context.{{../entity.name}}
+                {{#each ../entity.relations}}.Include(m => m.{{navigationProperty}}){{/each}}
+                .FirstOrDefaultAsync(m => m.Id == id);
+            {{else}}
+            var item = await _context.{{../entity.name}}
+                .FirstOrDefaultAsync(m => m.Id == id);
+            {{/if}}
+            if (item == null)
+            {
+                return NotFound();
+            }
+            {{#if ../manyToMany}}
+            {{#each ../manyToMany}}
+            ViewData["{{otherEntity}}List"] = await _context.{{joinEntity}}
+                .Where(j => j.{{thisKey}} == item.Id)
+                .Include(j => j.{{otherEntity}})
+                .Select(j => new { j.{{otherEntity}}!.Id, DisplayName = {{{detailsSelectExpression}}} })
+                .ToListAsync();
+            {{/each}}
+            {{/if}}
+
+            return View(item);
+        }
+        {{/if}}
+
         {{#if (eq type "create")}}
         // GET: {{../entity.name}}/Create
         {{#if requiredRole}}
@@ -98,6 +136,14 @@ namespace AspPrep.Controllers
                 .ToList();
             {{/each}}
             {{/if}}
+            {{#if ../manyToMany}}
+            {{#each ../manyToMany}}
+            ViewData["All{{otherEntity}}"] = _context.{{otherEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
+            {{/each}}
+            {{/if}}
             return View();
         }
 
@@ -107,12 +153,21 @@ namespace AspPrep.Controllers
         {{#if requiredRole}}
         [Authorize(Roles = "{{requiredRole}}")]
         {{/if}}
-        public async Task<IActionResult> Create([Bind("{{#each ../entity.properties}}{{name}}{{#unless @last}},{{/unless}}{{/each}}")] {{../entity.name}} item)
+        public async Task<IActionResult> Create([Bind("{{#each ../entity.properties}}{{name}}{{#unless @last}},{{/unless}}{{/each}}")] {{../entity.name}} item{{#if ../manyToMany}}, {{#each ../manyToMany}}int[] {{otherEntity}}Ids{{#unless @last}}, {{/unless}}{{/each}}{{/if}})
         {
             if (ModelState.IsValid)
             {
                 _context.Add(item);
                 await _context.SaveChangesAsync();
+                {{#if ../manyToMany}}
+                {{#each ../manyToMany}}
+                foreach (var oid in {{otherEntity}}Ids ?? Array.Empty<int>())
+                {
+                    _context.{{joinEntity}}.Add(new {{joinEntity}} { {{thisKey}} = item.Id, {{otherKey}} = oid });
+                }
+                {{/each}}
+                await _context.SaveChangesAsync();
+                {{/if}}
                 return RedirectToAction(nameof(Index));
             }
             {{#if ../entity.relations}}
@@ -121,6 +176,15 @@ namespace AspPrep.Controllers
                 .AsEnumerable()
                 .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
                 .ToList();
+            {{/each}}
+            {{/if}}
+            {{#if ../manyToMany}}
+            {{#each ../manyToMany}}
+            ViewData["All{{otherEntity}}"] = _context.{{otherEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
+            ViewData["Selected{{otherEntity}}Ids"] = {{otherEntity}}Ids.ToList();
             {{/each}}
             {{/if}}
             return View(item);
@@ -152,6 +216,18 @@ namespace AspPrep.Controllers
                 .ToList();
             {{/each}}
             {{/if}}
+            {{#if ../manyToMany}}
+            {{#each ../manyToMany}}
+            ViewData["All{{otherEntity}}"] = _context.{{otherEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
+            ViewData["Selected{{otherEntity}}Ids"] = _context.{{joinEntity}}
+                .Where(j => j.{{thisKey}} == id)
+                .Select(j => j.{{otherKey}})
+                .ToList();
+            {{/each}}
+            {{/if}}
             return View(item);
         }
 
@@ -161,7 +237,7 @@ namespace AspPrep.Controllers
         {{#if requiredRole}}
         [Authorize(Roles = "{{requiredRole}}")]
         {{/if}}
-        public async Task<IActionResult> Edit(int id, [Bind("Id,{{#each ../entity.properties}}{{name}}{{#unless @last}},{{/unless}}{{/each}}")] {{../entity.name}} item)
+        public async Task<IActionResult> Edit(int id, [Bind("Id,{{#each ../entity.properties}}{{name}}{{#unless @last}},{{/unless}}{{/each}}")] {{../entity.name}} item{{#if ../manyToMany}}, {{#each ../manyToMany}}int[] {{otherEntity}}Ids{{#unless @last}}, {{/unless}}{{/each}}{{/if}})
         {
             if (id != item.Id)
             {
@@ -174,6 +250,17 @@ namespace AspPrep.Controllers
                 {
                     _context.Update(item);
                     await _context.SaveChangesAsync();
+                    {{#if ../manyToMany}}
+                    {{#each ../manyToMany}}
+                    var existing{{otherEntity}} = _context.{{joinEntity}}.Where(j => j.{{thisKey}} == item.Id);
+                    _context.{{joinEntity}}.RemoveRange(existing{{otherEntity}});
+                    foreach (var oid in {{otherEntity}}Ids ?? Array.Empty<int>())
+                    {
+                        _context.{{joinEntity}}.Add(new {{joinEntity}} { {{thisKey}} = item.Id, {{otherKey}} = oid });
+                    }
+                    {{/each}}
+                    await _context.SaveChangesAsync();
+                    {{/if}}
                 }
                 catch (DbUpdateConcurrencyException)
                 {
@@ -194,6 +281,15 @@ namespace AspPrep.Controllers
                 .AsEnumerable()
                 .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
                 .ToList();
+            {{/each}}
+            {{/if}}
+            {{#if ../manyToMany}}
+            {{#each ../manyToMany}}
+            ViewData["All{{otherEntity}}"] = _context.{{otherEntity}}
+                .AsEnumerable()
+                .Select(m => new { m.Id, DisplayName = {{{selectExpression}}} })
+                .ToList();
+            ViewData["Selected{{otherEntity}}Ids"] = {{otherEntity}}Ids.ToList();
             {{/each}}
             {{/if}}
             return View(item);

--- a/generator/templates/Create.hbs
+++ b/generator/templates/Create.hbs
@@ -47,6 +47,24 @@
             </div>
             {{/each}}
             {{/if}}
+            {{#if manyToMany}}
+            {{#each manyToMany}}
+            <div class="form-group">
+                <label class="control-label">{{otherEntity}}</label>
+                @{
+                    var selected = ViewData["Selected{{otherEntity}}Ids"] as IEnumerable<int> ?? Enumerable.Empty<int>();
+                    var allItems = ViewData["All{{otherEntity}}"] as IEnumerable<dynamic> ?? Enumerable.Empty<dynamic>();
+                }
+                @foreach (var opt in allItems)
+                {
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="{{otherEntity}}Ids" value="@opt.Id" @(selected.Contains((int)opt.Id) ? "checked" : "") />
+                        <label class="form-check-label">@opt.DisplayName</label>
+                    </div>
+                }
+            </div>
+            {{/each}}
+            {{/if}}
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>

--- a/generator/templates/Details.hbs
+++ b/generator/templates/Details.hbs
@@ -1,0 +1,50 @@
+@model AspPrep.Models.{{entity.name}}
+
+@{
+    ViewData["Title"] = "{{entity.name}} Details";
+}
+
+<h1>{{entity.name}} Details</h1>
+
+<div>
+    <h4>{{entity.name}}</h4>
+    <hr />
+    <dl class="row">
+        {{#each entity.properties}}
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.{{name}})
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.{{name}})
+        </dd>
+        {{/each}}
+        {{#if entity.relations}}
+        {{#each entity.relations}}
+        <dt class="col-sm-2">
+            {{navigationProperty}}
+        </dt>
+        <dd class="col-sm-10">
+            @({{{displayInterpolationModel}}})
+        </dd>
+        {{/each}}
+        {{/if}}
+        {{#if manyToMany}}
+        {{#each manyToMany}}
+        <dt class="col-sm-2">
+            {{otherEntity}}
+        </dt>
+        <dd class="col-sm-10">
+            <ul>
+            @foreach (var rel in ViewData["{{otherEntity}}List"] as IEnumerable<dynamic>) {
+                <li>@rel.DisplayName</li>
+            }
+            </ul>
+        </dd>
+        {{/each}}
+        {{/if}}
+    </dl>
+</div>
+<div>
+    <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a> |
+    <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+</div>

--- a/generator/templates/Edit.hbs
+++ b/generator/templates/Edit.hbs
@@ -48,6 +48,24 @@
             </div>
             {{/each}}
             {{/if}}
+            {{#if manyToMany}}
+            {{#each manyToMany}}
+            <div class="form-group">
+                <label class="control-label">{{otherEntity}}</label>
+                @{
+                    var selected = ViewData["Selected{{otherEntity}}Ids"] as IEnumerable<int> ?? Enumerable.Empty<int>();
+                    var allItems = ViewData["All{{otherEntity}}"] as IEnumerable<dynamic> ?? Enumerable.Empty<dynamic>();
+                }
+                @foreach (var opt in allItems)
+                {
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="{{otherEntity}}Ids" value="@opt.Id" @(selected.Contains((int)opt.Id) ? "checked" : "") />
+                        <label class="form-check-label">@opt.DisplayName</label>
+                    </div>
+                }
+            </div>
+            {{/each}}
+            {{/if}}
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-primary" />
             </div>


### PR DESCRIPTION
## Summary
- add `details` operation type
- generate many-to-many helpers
- create Details page template
- support multiselect checkboxes for many-to-many relations in create and edit views
- load related data in controllers and show relations on details page

## Testing
- `npm run generate:controllers`
- `npm run generate:all`


------
https://chatgpt.com/codex/tasks/task_e_6847d81fa8cc832e89f7d913a245ad40